### PR TITLE
Standardize bibliography formatting

### DIFF
--- a/science-case/references.bib
+++ b/science-case/references.bib
@@ -5,7 +5,7 @@
    volume={90},
    ISSN={1079-7114},
    url={http://dx.doi.org/10.1103/PhysRevLett.90.091301},
-   DOI={10.1103/physrevlett.90.091301},
+   doi={10.1103/physrevlett.90.091301},
    number={9},
    journal={Physical Review Letters},
    publisher={American Physical Society (APS)},
@@ -24,7 +24,7 @@
   year = {1989},
   month = {Jan},
   publisher = {American Physical Society},
-  DOI = {10.1103/RevModPhys.61.1},
+  doi = {10.1103/RevModPhys.61.1},
   url = {https://link.aps.org/doi/10.1103/RevModPhys.61.1}
 }
 
@@ -34,7 +34,7 @@
    volume={8},
    ISSN={1367-2630},
    url={http://dx.doi.org/10.1088/1367-2630/8/7/123},
-   DOI={10.1088/1367-2630/8/7/123},
+   doi={10.1088/1367-2630/8/7/123},
    number={7},
    journal={New Journal of Physics},
    publisher={IOP Publishing},
@@ -47,7 +47,7 @@
    volume={641},
    ISSN={1432-0746},
    url={http://dx.doi.org/10.1051/0004-6361/201833910},
-   DOI={10.1051/0004-6361/201833910},
+   doi={10.1051/0004-6361/201833910},
    journal={Astronomy &amp; Astrophysics},
    publisher={EDP Sciences},
    author={Aghanim, N. and Akrami, Y. and Ashdown, M. and Aumont, J. and Baccigalupi, C. and Ballardini, M. and Banday, A. J. and Barreiro, R. B. and Bartolo, N. and Basak, S. and Battye, R. and Benabed, K. and Bernard, J.-P. and Bersanelli, M. and Bielewicz, P. and Bock, J. J. and Bond, J. R. and Borrill, J. and Bouchet, F. R. and Boulanger, F. and Bucher, M. and Burigana, C. and Butler, R. C. and Calabrese, E. and Cardoso, J.-F. and Carron, J. and Challinor, A. and Chiang, H. C. and Chluba, J. and Colombo, L. P. L. and Combet, C. and Contreras, D. and Crill, B. P. and Cuttaia, F. and de Bernardis, P. and de Zotti, G. and Delabrouille, J. and Delouis, J.-M. and Di Valentino, E. and Diego, J. M. and Doré, O. and Douspis, M. and Ducout, A. and Dupac, X. and Dusini, S. and Efstathiou, G. and Elsner, F. and Enßlin, T. A. and Eriksen, H. K. and Fantaye, Y. and Farhang, M. and Fergusson, J. and Fernandez-Cobos, R. and Finelli, F. and Forastieri, F. and Frailis, M. and Fraisse, A. A. and Franceschi, E. and Frolov, A. and Galeotta, S. and Galli, S. and Ganga, K. and Génova-Santos, R. T. and Gerbino, M. and Ghosh, T. and González-Nuevo, J. and Górski, K. M. and Gratton, S. and Gruppuso, A. and Gudmundsson, J. E. and Hamann, J. and Handley, W. and Hansen, F. K. and Herranz, D. and Hildebrandt, S. R. and Hivon, E. and Huang, Z. and Jaffe, A. H. and Jones, W. C. and Karakci, A. and Keihänen, E. and Keskitalo, R. and Kiiveri, K. and Kim, J. and Kisner, T. S. and Knox, L. and Krachmalnicoff, N. and Kunz, M. and Kurki-Suonio, H. and Lagache, G. and Lamarre, J.-M. and Lasenby, A. and Lattanzi, M. and Lawrence, C. R. and Le Jeune, M. and Lemos, P. and Lesgourgues, J. and Levrier, F. and Lewis, A. and Liguori, M. and Lilje, P. B. and Lilley, M. and Lindholm, V. and López-Caniego, M. and Lubin, P. M. and Ma, Y.-Z. and Macías-Pérez, J. F. and Maggio, G. and Maino, D. and Mandolesi, N. and Mangilli, A. and Marcos-Caballero, A. and Maris, M. and Martin, P. G. and Martinelli, M. and Martínez-González, E. and Matarrese, S. and Mauri, N. and McEwen, J. D. and Meinhold, P. R. and Melchiorri, A. and Mennella, A. and Migliaccio, M. and Millea, M. and Mitra, S. and Miville-Deschênes, M.-A. and Molinari, D. and Montier, L. and Morgante, G. and Moss, A. and Natoli, P. and Nørgaard-Nielsen, H. U. and Pagano, L. and Paoletti, D. and Partridge, B. and Patanchon, G. and Peiris, H. V. and Perrotta, F. and Pettorino, V. and Piacentini, F. and Polastri, L. and Polenta, G. and Puget, J.-L. and Rachen, J. P. and Reinecke, M. and Remazeilles, M. and Renzi, A. and Rocha, G. and Rosset, C. and Roudier, G. and Rubiño-Martín, J. A. and Ruiz-Granados, B. and Salvati, L. and Sandri, M. and Savelainen, M. and Scott, D. and Shellard, E. P. S. and Sirignano, C. and Sirri, G. and Spencer, L. D. and Sunyaev, R. and Suur-Uski, A.-S. and Tauber, J. A. and Tavagnacco, D. and Tenti, M. and Toffolatti, L. and Tomasi, M. and Trombetti, T. and Valenziano, L. and Valiviita, J. and Van Tent, B. and Vibert, L. and Vielva, P. and Villa, F. and Vittorio, N. and Wandelt, B. D. and Wehus, I. K. and White, M. and White, S. D. M. and Zacchei, A. and Zonca, A.},
@@ -70,7 +70,7 @@
    volume={22},
    ISSN={1793-6594},
    url={http://dx.doi.org/10.1142/S0218271813300280},
-   DOI={10.1142/s0218271813300280},
+   doi={10.1142/s0218271813300280},
    number={14},
    journal={International Journal of Modern Physics D},
    publisher={World Scientific Pub Co Pte Lt},
@@ -106,7 +106,7 @@
    volume={52},
    ISSN={1572-9508},
    url={http://dx.doi.org/10.1007/s10686-021-09779-9},
-   DOI={10.1007/s10686-021-09779-9},
+   doi={10.1007/s10686-021-09779-9},
    number={1-2},
    journal={Experimental Astronomy},
    publisher={Springer Science and Business Media LLC},
@@ -119,7 +119,7 @@
 @inproceedings{Fiore_2020,
    title={The HERMES-technologic and scientific pathfinder},
    url={http://dx.doi.org/10.1117/12.2560680},
-   DOI={10.1117/12.2560680},
+   doi={10.1117/12.2560680},
    booktitle={Space Telescopes and Instrumentation 2020: Ultraviolet to Gamma Ray},
    publisher={SPIE},
 	 author={Fiore, Fabrizio and others},
@@ -141,7 +141,7 @@
   number = {3},
   pages = {168--173},
   year = {1929},
-  DOI = {10.1073/pnas.15.3.168},
+  doi = {10.1073/pnas.15.3.168},
   URL = {https://www.pnas.org/doi/abs/10.1073/pnas.15.3.168},
   eprint = {https://www.pnas.org/doi/pdf/10.1073/pnas.15.3.168}
 }
@@ -168,7 +168,7 @@
         month = jul,
        volume = {142},
         pages = {419--421},
-          DOI = {10.1086/148307},
+          doi = {10.1086/148307},
        adsurl = {https://ui.adsabs.harvard.edu/abs/1965ApJ...142..419P},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
@@ -182,7 +182,7 @@
         month = jul,
        volume = {142},
         pages = {414--419},
-          DOI = {10.1086/148306},
+          doi = {10.1086/148306},
        adsurl = {https://ui.adsabs.harvard.edu/abs/1965ApJ...142..414D},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
@@ -192,7 +192,7 @@
    volume={116},
    ISSN={0004-6256},
    url={http://dx.doi.org/10.1086/300499},
-   DOI={10.1086/300499},
+   doi={10.1086/300499},
    number={3},
    journal={The Astronomical Journal},
    publisher={American Astronomical Society},
@@ -203,7 +203,7 @@
 }
 
 @article{Perlmutter_1999,
-DOI = {10.1086/307221},
+doi = {10.1086/307221},
 url = {https://doi.org/10.1086/307221},
 year = {1999},
 month = {jun},
@@ -219,7 +219,7 @@ abstract = {We report measurements of the mass density, ΩM, and cosmological-co
 }
 
 @article{Di_Valentino_2021,
-DOI = {10.1088/1361-6382/ac086d},
+doi = {10.1088/1361-6382/ac086d},
 url = {https://doi.org/10.1088/1361-6382/ac086d},
 year = {2021},
 month = {jul},

--- a/science-case/references.bib
+++ b/science-case/references.bib
@@ -24,7 +24,7 @@
   year = {1989},
   month = {Jan},
   publisher = {American Physical Society},
-  doi = {10.1103/RevModPhys.61.1},
+  DOI = {10.1103/RevModPhys.61.1},
   url = {https://link.aps.org/doi/10.1103/RevModPhys.61.1}
 }
 
@@ -50,7 +50,7 @@
    DOI={10.1051/0004-6361/201833910},
    journal={Astronomy &amp; Astrophysics},
    publisher={EDP Sciences},
-   author={ and Aghanim, N. and Akrami, Y. and Ashdown, M. and Aumont, J. and Baccigalupi, C. and Ballardini, M. and Banday, A. J. and Barreiro, R. B. and Bartolo, N. and Basak, S. and Battye, R. and Benabed, K. and Bernard, J.-P. and Bersanelli, M. and Bielewicz, P. and Bock, J. J. and Bond, J. R. and Borrill, J. and Bouchet, F. R. and Boulanger, F. and Bucher, M. and Burigana, C. and Butler, R. C. and Calabrese, E. and Cardoso, J.-F. and Carron, J. and Challinor, A. and Chiang, H. C. and Chluba, J. and Colombo, L. P. L. and Combet, C. and Contreras, D. and Crill, B. P. and Cuttaia, F. and de Bernardis, P. and de Zotti, G. and Delabrouille, J. and Delouis, J.-M. and Di Valentino, E. and Diego, J. M. and Doré, O. and Douspis, M. and Ducout, A. and Dupac, X. and Dusini, S. and Efstathiou, G. and Elsner, F. and Enßlin, T. A. and Eriksen, H. K. and Fantaye, Y. and Farhang, M. and Fergusson, J. and Fernandez-Cobos, R. and Finelli, F. and Forastieri, F. and Frailis, M. and Fraisse, A. A. and Franceschi, E. and Frolov, A. and Galeotta, S. and Galli, S. and Ganga, K. and Génova-Santos, R. T. and Gerbino, M. and Ghosh, T. and González-Nuevo, J. and Górski, K. M. and Gratton, S. and Gruppuso, A. and Gudmundsson, J. E. and Hamann, J. and Handley, W. and Hansen, F. K. and Herranz, D. and Hildebrandt, S. R. and Hivon, E. and Huang, Z. and Jaffe, A. H. and Jones, W. C. and Karakci, A. and Keihänen, E. and Keskitalo, R. and Kiiveri, K. and Kim, J. and Kisner, T. S. and Knox, L. and Krachmalnicoff, N. and Kunz, M. and Kurki-Suonio, H. and Lagache, G. and Lamarre, J.-M. and Lasenby, A. and Lattanzi, M. and Lawrence, C. R. and Le Jeune, M. and Lemos, P. and Lesgourgues, J. and Levrier, F. and Lewis, A. and Liguori, M. and Lilje, P. B. and Lilley, M. and Lindholm, V. and López-Caniego, M. and Lubin, P. M. and Ma, Y.-Z. and Macías-Pérez, J. F. and Maggio, G. and Maino, D. and Mandolesi, N. and Mangilli, A. and Marcos-Caballero, A. and Maris, M. and Martin, P. G. and Martinelli, M. and Martínez-González, E. and Matarrese, S. and Mauri, N. and McEwen, J. D. and Meinhold, P. R. and Melchiorri, A. and Mennella, A. and Migliaccio, M. and Millea, M. and Mitra, S. and Miville-Deschênes, M.-A. and Molinari, D. and Montier, L. and Morgante, G. and Moss, A. and Natoli, P. and Nørgaard-Nielsen, H. U. and Pagano, L. and Paoletti, D. and Partridge, B. and Patanchon, G. and Peiris, H. V. and Perrotta, F. and Pettorino, V. and Piacentini, F. and Polastri, L. and Polenta, G. and Puget, J.-L. and Rachen, J. P. and Reinecke, M. and Remazeilles, M. and Renzi, A. and Rocha, G. and Rosset, C. and Roudier, G. and Rubiño-Martín, J. A. and Ruiz-Granados, B. and Salvati, L. and Sandri, M. and Savelainen, M. and Scott, D. and Shellard, E. P. S. and Sirignano, C. and Sirri, G. and Spencer, L. D. and Sunyaev, R. and Suur-Uski, A.-S. and Tauber, J. A. and Tavagnacco, D. and Tenti, M. and Toffolatti, L. and Tomasi, M. and Trombetti, T. and Valenziano, L. and Valiviita, J. and Van Tent, B. and Vibert, L. and Vielva, P. and Villa, F. and Vittorio, N. and Wandelt, B. D. and Wehus, I. K. and White, M. and White, S. D. M. and Zacchei, A. and Zonca, A.},
+   author={Aghanim, N. and Akrami, Y. and Ashdown, M. and Aumont, J. and Baccigalupi, C. and Ballardini, M. and Banday, A. J. and Barreiro, R. B. and Bartolo, N. and Basak, S. and Battye, R. and Benabed, K. and Bernard, J.-P. and Bersanelli, M. and Bielewicz, P. and Bock, J. J. and Bond, J. R. and Borrill, J. and Bouchet, F. R. and Boulanger, F. and Bucher, M. and Burigana, C. and Butler, R. C. and Calabrese, E. and Cardoso, J.-F. and Carron, J. and Challinor, A. and Chiang, H. C. and Chluba, J. and Colombo, L. P. L. and Combet, C. and Contreras, D. and Crill, B. P. and Cuttaia, F. and de Bernardis, P. and de Zotti, G. and Delabrouille, J. and Delouis, J.-M. and Di Valentino, E. and Diego, J. M. and Doré, O. and Douspis, M. and Ducout, A. and Dupac, X. and Dusini, S. and Efstathiou, G. and Elsner, F. and Enßlin, T. A. and Eriksen, H. K. and Fantaye, Y. and Farhang, M. and Fergusson, J. and Fernandez-Cobos, R. and Finelli, F. and Forastieri, F. and Frailis, M. and Fraisse, A. A. and Franceschi, E. and Frolov, A. and Galeotta, S. and Galli, S. and Ganga, K. and Génova-Santos, R. T. and Gerbino, M. and Ghosh, T. and González-Nuevo, J. and Górski, K. M. and Gratton, S. and Gruppuso, A. and Gudmundsson, J. E. and Hamann, J. and Handley, W. and Hansen, F. K. and Herranz, D. and Hildebrandt, S. R. and Hivon, E. and Huang, Z. and Jaffe, A. H. and Jones, W. C. and Karakci, A. and Keihänen, E. and Keskitalo, R. and Kiiveri, K. and Kim, J. and Kisner, T. S. and Knox, L. and Krachmalnicoff, N. and Kunz, M. and Kurki-Suonio, H. and Lagache, G. and Lamarre, J.-M. and Lasenby, A. and Lattanzi, M. and Lawrence, C. R. and Le Jeune, M. and Lemos, P. and Lesgourgues, J. and Levrier, F. and Lewis, A. and Liguori, M. and Lilje, P. B. and Lilley, M. and Lindholm, V. and López-Caniego, M. and Lubin, P. M. and Ma, Y.-Z. and Macías-Pérez, J. F. and Maggio, G. and Maino, D. and Mandolesi, N. and Mangilli, A. and Marcos-Caballero, A. and Maris, M. and Martin, P. G. and Martinelli, M. and Martínez-González, E. and Matarrese, S. and Mauri, N. and McEwen, J. D. and Meinhold, P. R. and Melchiorri, A. and Mennella, A. and Migliaccio, M. and Millea, M. and Mitra, S. and Miville-Deschênes, M.-A. and Molinari, D. and Montier, L. and Morgante, G. and Moss, A. and Natoli, P. and Nørgaard-Nielsen, H. U. and Pagano, L. and Paoletti, D. and Partridge, B. and Patanchon, G. and Peiris, H. V. and Perrotta, F. and Pettorino, V. and Piacentini, F. and Polastri, L. and Polenta, G. and Puget, J.-L. and Rachen, J. P. and Reinecke, M. and Remazeilles, M. and Renzi, A. and Rocha, G. and Rosset, C. and Roudier, G. and Rubiño-Martín, J. A. and Ruiz-Granados, B. and Salvati, L. and Sandri, M. and Savelainen, M. and Scott, D. and Shellard, E. P. S. and Sirignano, C. and Sirri, G. and Spencer, L. D. and Sunyaev, R. and Suur-Uski, A.-S. and Tauber, J. A. and Tavagnacco, D. and Tenti, M. and Toffolatti, L. and Tomasi, M. and Trombetti, T. and Valenziano, L. and Valiviita, J. and Van Tent, B. and Vibert, L. and Vielva, P. and Villa, F. and Vittorio, N. and Wandelt, B. D. and Wehus, I. K. and White, M. and White, S. D. M. and Zacchei, A. and Zonca, A.},
    year={2020},
    month=Sept, pages={A6} }
 
@@ -139,9 +139,9 @@
   journal = {Proceedings of the National Academy of Sciences},
   volume = {15},
   number = {3},
-  pages = {168-173},
+  pages = {168--173},
   year = {1929},
-  doi = {10.1073/pnas.15.3.168},
+  DOI = {10.1073/pnas.15.3.168},
   URL = {https://www.pnas.org/doi/abs/10.1073/pnas.15.3.168},
   eprint = {https://www.pnas.org/doi/pdf/10.1073/pnas.15.3.168}
 }
@@ -154,7 +154,7 @@
          year = 1927,
         month = jan,
        volume = {47},
-        pages = {49-59},
+        pages = {49--59},
        adsurl = {https://ui.adsabs.harvard.edu/abs/1927ASSB...47...49L},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
@@ -167,8 +167,8 @@
          year = 1965,
         month = jul,
        volume = {142},
-        pages = {419-421},
-          doi = {10.1086/148307},
+        pages = {419--421},
+          DOI = {10.1086/148307},
        adsurl = {https://ui.adsabs.harvard.edu/abs/1965ApJ...142..419P},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
@@ -181,8 +181,8 @@
          year = 1965,
         month = jul,
        volume = {142},
-        pages = {414-419},
-          doi = {10.1086/148306},
+        pages = {414--419},
+          DOI = {10.1086/148306},
        adsurl = {https://ui.adsabs.harvard.edu/abs/1965ApJ...142..414D},
       adsnote = {Provided by the SAO/NASA Astrophysics Data System}
 }
@@ -203,7 +203,7 @@
 }
 
 @article{Perlmutter_1999,
-doi = {10.1086/307221},
+DOI = {10.1086/307221},
 url = {https://doi.org/10.1086/307221},
 year = {1999},
 month = {jun},
@@ -219,7 +219,7 @@ abstract = {We report measurements of the mass density, ΩM, and cosmological-co
 }
 
 @article{Di_Valentino_2021,
-doi = {10.1088/1361-6382/ac086d},
+DOI = {10.1088/1361-6382/ac086d},
 url = {https://doi.org/10.1088/1361-6382/ac086d},
 year = {2021},
 month = {jul},


### PR DESCRIPTION
I standardized a few bibliography entries by:
- Making DOI formatting consistent with doi.
- Replacing "-" page dashes with BibTeX page-range dashes "--".
- Correcting Planck, whose author list began with "and".

This is my first contribution, and it's a very small one since I’m still getting familiar with the workflow. Please let me know if I got anything wrong.